### PR TITLE
CompatHelper: bump compat for AutoDiffOperators to 0.3, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Newtrinos"
 uuid = "5b289081-bab5-45e8-97fc-86872f1653a0"
-authors = ["Philipp Eller"]
 version = "0.0.1"
+authors = ["Philipp Eller"]
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -67,7 +67,7 @@ ADTypes = "1.14.0"
 Accessors = "0.1.42"
 ArgParse = "1.2.0"
 ArraysOfArrays = "0.6.5"
-AutoDiffOperators = "0.2.1"
+AutoDiffOperators = "0.2.1, 0.3"
 BAT = "3.3.4, 4"
 Bessels = "0.2.8"
 Bijections = "0.1, 0.2"


### PR DESCRIPTION
This pull request changes the compat entry for the `AutoDiffOperators` package from `0.2.1` to `0.2.1, 0.3`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.