### PR TITLE
CompatHelper: bump compat for Optimization to 5, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Newtrinos"
 uuid = "5b289081-bab5-45e8-97fc-86872f1653a0"
-authors = ["Philipp Eller"]
 version = "0.0.1"
+authors = ["Philipp Eller"]
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -106,7 +106,7 @@ MeasureBase = "0.14.13"
 Memoize = "0.4.4"
 Mooncake = "0.4.108"
 Optim = "1.11.0"
-Optimization = "4.1.1"
+Optimization = "4.1.1, 5"
 PDMats = "0.11"
 PairPlots = "3.0.1"
 PositiveFactorizations = "0.2.4"


### PR DESCRIPTION
This pull request changes the compat entry for the `Optimization` package from `4.1.1` to `4.1.1, 5`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.