### PR TITLE
CompatHelper: bump compat for JET to 0.11, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Newtrinos"
 uuid = "5b289081-bab5-45e8-97fc-86872f1653a0"
-version = "0.0.1"
 authors = ["Philipp Eller"]
+version = "0.0.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -93,7 +93,7 @@ HDF5 = "0.17.2"
 Interpolations = "0.15.1, 0.16"
 InverseFunctions = "0.1.17"
 IterTools = "1.10.0"
-JET = "0.9.18, 0.10"
+JET = "0.9.18, 0.10, 0.11"
 JLD2 = "0.5.11, 0.6"
 LibGit2 = "1.11.0"
 LinearAlgebra = "1.11.0"


### PR DESCRIPTION
This pull request changes the compat entry for the `JET` package from `0.9.18, 0.10` to `0.9.18, 0.10, 0.11`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.